### PR TITLE
Refactor grid components

### DIFF
--- a/docs-src/src/main/scala/docs/Index.scala
+++ b/docs-src/src/main/scala/docs/Index.scala
@@ -28,8 +28,8 @@ object Index extends HepekDocsStaticPage {
         h1("Welcome!")
       ),
       row(
-        third1(),
-        third2(
+        third(),
+        third(
           """
             Hepek turns Scala `object`s into files.
             Everything you can `println` to screen *Hepek* can write to a file.
@@ -60,7 +60,7 @@ object Index extends HepekDocsStaticPage {
 
           """.md
         ),
-        third3()
+        third()
       ),
       super.pageContent
     )

--- a/docs-src/src/main/scala/utils/Imports.scala
+++ b/docs-src/src/main/scala/utils/Imports.scala
@@ -14,10 +14,6 @@ object Imports extends BootstrapBundle with BasicComponents {
 
   object chl extends PrismCodeHighlightComponents
 
-  object grid extends Grid {
-    override def screenRatios = super.screenRatios.withSm(None).withXs(None)
-  }
-
   // FontAwesome 5 brand
   def faBrand(name: String) = i(cls := s"fab fa-$name")
 

--- a/src/main/scala/ba/sake/hepek/bootstrap3/component/BootstrapGridComponents.scala
+++ b/src/main/scala/ba/sake/hepek/bootstrap3/component/BootstrapGridComponents.scala
@@ -23,7 +23,6 @@ trait BootstrapGridComponents extends GridComponents {
 
   /* HELPERS */
   private def halfRatioClasses(index: Int): List[String] = {
-    println(s"screenRatios=$screenRatios, i=$index")
     val lg = lgClass(screenRatios.lg.half, index)
     val md = screenRatios.md.map(r => mdClass(r.half, index))
     val sm = screenRatios.sm.map(r => smClass(r.half, index))

--- a/src/main/scala/ba/sake/hepek/bootstrap3/component/BootstrapGridComponents.scala
+++ b/src/main/scala/ba/sake/hepek/bootstrap3/component/BootstrapGridComponents.scala
@@ -8,15 +8,15 @@ object BootstrapGridComponents extends BootstrapGridComponents
 trait BootstrapGridComponents extends GridComponents {
   import GridComponents._
 
-  override def mkRow(content: Frag*): Frag =
+  private[hepek] override def mkRow(content: Frag*): Frag =
     div(cls := "row")(content)
 
-  override def mkCol2(index: Int, content: List[Frag]): Frag = {
+  private[hepek] override def mkCol2(index: Int, content: List[Frag]): Frag = {
     val classes = halfRatioClasses(index)
     div(cls := classes.mkString(" "))(content)
   }
 
-  override def mkCol3(index: Int, content: List[Frag]): Frag = {
+  private[hepek] override def mkCol3(index: Int, content: List[Frag]): Frag = {
     val classes = thirdRatioClasses(index)
     div(cls := classes.mkString(" "))(content)
   }

--- a/src/main/scala/ba/sake/hepek/bootstrap3/component/BootstrapGridComponents.scala
+++ b/src/main/scala/ba/sake/hepek/bootstrap3/component/BootstrapGridComponents.scala
@@ -8,49 +8,22 @@ object BootstrapGridComponents extends BootstrapGridComponents
 trait BootstrapGridComponents extends GridComponents {
   import GridComponents._
 
-  override def row(content: Frag*) =
+  override def mkRow(content: Frag*): Frag =
     div(cls := "row")(content)
 
-  override def row(half1: Half1, half2: Half2) =
-    row(half1.content ++ half2.content)
-
-  override def row(third1: Third1, third2: Third2, third3: Third3) =
-    row(third1.content ++ third2.content ++ third3.content)
-
-  // HALF
-  override def half1(content: Frag*) = {
-    val classes = halfRatioClasses(0)
-    val c       = div(cls := classes.mkString(" "))(content)
-    Half1(List(c))
+  override def mkCol2(index: Int, content: List[Frag]): Frag = {
+    val classes = halfRatioClasses(index)
+    div(cls := classes.mkString(" "))(content)
   }
 
-  override def half2(content: Frag*) = {
-    val classes = halfRatioClasses(1)
-    val c       = div(cls := classes.mkString(" "))(content)
-    Half2(List(c))
-  }
-
-  // THIRD
-  override def third1(content: Frag*) = {
-    val classes = thirdRatioClasses(0)
-    val c       = div(cls := classes.mkString(" "))(content)
-    Third1(List(c))
-  }
-
-  override def third2(content: Frag*) = {
-    val classes = thirdRatioClasses(1)
-    val c       = div(cls := classes.mkString(" "))(content)
-    Third2(List(c))
-  }
-
-  override def third3(content: Frag*) = {
-    val classes = thirdRatioClasses(2)
-    val c       = div(cls := classes.mkString(" "))(content)
-    Third3(List(c))
+  override def mkCol3(index: Int, content: List[Frag]): Frag = {
+    val classes = thirdRatioClasses(index)
+    div(cls := classes.mkString(" "))(content)
   }
 
   /* HELPERS */
   private def halfRatioClasses(index: Int): List[String] = {
+    println(s"screenRatios=$screenRatios, i=$index")
     val lg = lgClass(screenRatios.lg.half, index)
     val md = screenRatios.md.map(r => mdClass(r.half, index))
     val sm = screenRatios.sm.map(r => smClass(r.half, index))

--- a/src/main/scala/ba/sake/hepek/bulma/grid/BulmaGridComponents.scala
+++ b/src/main/scala/ba/sake/hepek/bulma/grid/BulmaGridComponents.scala
@@ -10,41 +10,16 @@ trait BulmaGridComponents extends GridComponents {
   import GridComponents._
   import ba.sake.hepek.bulma.component.enrichCssClasses
 
-  def row(modifiers: BulmaModifier*)(content: Frag*) =
-    div(cls := enrichCssClasses("columns", modifiers))(content)
-
-  override def row(content: Frag*) =
+  override def mkRow(content: Frag*): Frag =
     div(cls := "columns")(content)
 
-  override def row(half1: Half1, half2: Half2) =
-    row(half1.content ++ half2.content)
+  // TODO add responsiveness
+  override def mkCol2(index: Int, content: List[Frag]): Frag =
+    div(cls := "column")(content)
 
-  override def row(third1: Third1, third2: Third2, third3: Third3) =
-    row(third1.content ++ third2.content ++ third3.content)
+  override def mkCol3(index: Int, content: List[Frag]): Frag =
+    div(cls := "column")(content)
 
-  override def half1(content: Frag*) = {
-    val c = div(cls := "column")(content)
-    Half1(List(c))
-  }
-
-  override def half2(content: Frag*) = {
-    val c = div(cls := "column")(content)
-    Half2(List(c))
-  }
-
-  override def third1(content: Frag*) = {
-    val c = div(cls := "column")(content)
-    Third1(List(c))
-  }
-
-  override def third2(content: Frag*) = {
-    val c = div(cls := "column")(content)
-    Third2(List(c))
-  }
-
-  override def third3(content: Frag*) = {
-    val c = div(cls := "column")(content)
-    Third3(List(c))
-  }
-
+  def row(modifiers: BulmaModifier*)(content: Frag*) =
+    div(cls := enrichCssClasses("columns", modifiers))(content)
 }

--- a/src/main/scala/ba/sake/hepek/bulma/grid/BulmaGridComponents.scala
+++ b/src/main/scala/ba/sake/hepek/bulma/grid/BulmaGridComponents.scala
@@ -10,14 +10,14 @@ trait BulmaGridComponents extends GridComponents {
   import GridComponents._
   import ba.sake.hepek.bulma.component.enrichCssClasses
 
-  override def mkRow(content: Frag*): Frag =
+  private[hepek] override def mkRow(content: Frag*): Frag =
     div(cls := "columns")(content)
 
   // TODO add responsiveness
-  override def mkCol2(index: Int, content: List[Frag]): Frag =
+  private[hepek] override def mkCol2(index: Int, content: List[Frag]): Frag =
     div(cls := "column")(content)
 
-  override def mkCol3(index: Int, content: List[Frag]): Frag =
+  private[hepek] override def mkCol3(index: Int, content: List[Frag]): Frag =
     div(cls := "column")(content)
 
   def row(modifiers: BulmaModifier*)(content: Frag*) =

--- a/src/main/scala/ba/sake/hepek/html/component/GridComponents.scala
+++ b/src/main/scala/ba/sake/hepek/html/component/GridComponents.scala
@@ -5,9 +5,9 @@ import scalatags.Text.all._
 trait GridComponents {
   import GridComponents._
 
-  def mkRow(content: Frag*): Frag
-  def mkCol2(index: Int, content: List[Frag]): Frag // make a "half"
-  def mkCol3(index: Int, content: List[Frag]): Frag // make a "third"
+  private[hepek] def mkRow(content: Frag*): Frag
+  private[hepek] def mkCol2(index: Int, content: List[Frag]): Frag // make a "half"
+  private[hepek] def mkCol3(index: Int, content: List[Frag]): Frag // make a "third"
 
   // ROW
   def row(half1: Half, half2: Half): Frag =

--- a/src/main/scala/ba/sake/hepek/html/component/GridComponents.scala
+++ b/src/main/scala/ba/sake/hepek/html/component/GridComponents.scala
@@ -5,6 +5,21 @@ import scalatags.Text.all._
 trait GridComponents {
   import GridComponents._
 
+  def mkRow(content: Frag*): Frag
+  def mkCol2(index: Int, content: List[Frag]): Frag // make a "half"
+  def mkCol3(index: Int, content: List[Frag]): Frag // make a "third"
+
+  // ROW
+  def row(half1: Half, half2: Half): Frag =
+    mkRow(mkCol2(0, half1.content), mkCol2(1, half2.content))
+
+  def row(third1: Third, third2: Third, third3: Third): Frag =
+    mkRow(mkCol3(0, third1.content), mkCol3(1, third2.content), mkCol3(2, third3.content))
+
+  def half(content: Frag*): Half = Half(content.toList)
+
+  def third(content: Frag*): Third = Third(content.toList)
+
   /** Same on all screens, by default */
   def screenRatios: ScreenRatios = ScreenRatios(
     Ratios.Default,
@@ -12,30 +27,12 @@ trait GridComponents {
     Option(Ratios.Default),
     Option(Ratios.Default)
   )
-
-  // ROW
-  def row(content: Frag*): Frag
-  def row(half1: Half1, half2: Half2): Frag
-  def row(third1: Third1, third2: Third2, third3: Third3): Frag
-
-  // HALF
-  def half1(content: Frag*): Half1
-  def half2(content: Frag*): Half2
-
-  // THIRD
-  def third1(content: Frag*): Third1
-  def third2(content: Frag*): Third2
-  def third3(content: Frag*): Third3
 }
 
 object GridComponents {
 
-  case class Half1(content: List[Frag])
-  case class Half2(content: List[Frag])
-
-  case class Third1(content: List[Frag])
-  case class Third2(content: List[Frag])
-  case class Third3(content: List[Frag])
+  case class Half(content: List[Frag])
+  case class Third(content: List[Frag])
 
   case class Ratio(values: List[Int])
 

--- a/src/main/scala/ba/sake/hepek/html/component/GridComponents.scala
+++ b/src/main/scala/ba/sake/hepek/html/component/GridComponents.scala
@@ -11,10 +11,17 @@ trait GridComponents {
 
   // ROW
   def row(half1: Half, half2: Half): Frag =
-    mkRow(mkCol2(0, half1.content), mkCol2(1, half2.content))
+    mkRow(
+      mkCol2(0, half1.content),
+      mkCol2(1, half2.content)
+    )
 
   def row(third1: Third, third2: Third, third3: Third): Frag =
-    mkRow(mkCol3(0, third1.content), mkCol3(1, third2.content), mkCol3(2, third3.content))
+    mkRow(
+      mkCol3(0, third1.content),
+      mkCol3(1, third2.content),
+      mkCol3(2, third3.content)
+    )
 
   def half(content: Frag*): Half = Half(content.toList)
 

--- a/src/main/scala/ba/sake/hepek/html/component/Modifiers.scala
+++ b/src/main/scala/ba/sake/hepek/html/component/Modifiers.scala
@@ -3,6 +3,9 @@ package ba.sake.hepek.html.component
 import scalatags.Text.all._
 
 trait Modifiers {
+  // TODO extract common classes
+  // https://www.w3schools.com/bootstrap/bootstrap_ref_css_buttons.asp
+  // https://purecss.io/buttons/
   def btn: AttrPair
   def btnSuccess: AttrPair
 }
@@ -15,10 +18,4 @@ object BsModifiers extends Modifiers {
 object PureModifiers extends Modifiers {
   def btn        = cls := "pure-button"
   def btnSuccess = cls := "pure-button-primary"
-}
-
-object Bla extends App {
-  import PureModifiers._
-  println(div(btn)("aaaaaaaaaa"))
-  println(div(btn, btnSuccess)("aaaaaaaaaa"))
 }

--- a/src/main/scala/ba/sake/hepek/html/component/Modifiers.scala
+++ b/src/main/scala/ba/sake/hepek/html/component/Modifiers.scala
@@ -1,0 +1,24 @@
+package ba.sake.hepek.html.component
+
+import scalatags.Text.all._
+
+trait Modifiers {
+  def btn: AttrPair
+  def btnSuccess: AttrPair
+}
+
+object BsModifiers extends Modifiers {
+  def btn        = cls := "btn"
+  def btnSuccess = cls := "btn-success"
+}
+
+object PureModifiers extends Modifiers {
+  def btn        = cls := "pure-button"
+  def btnSuccess = cls := "pure-button-primary"
+}
+
+object Bla extends App {
+  import PureModifiers._
+  println(div(btn)("aaaaaaaaaa"))
+  println(div(btn, btnSuccess)("aaaaaaaaaa"))
+}

--- a/src/main/scala/ba/sake/hepek/pure/component/PureGridComponents.scala
+++ b/src/main/scala/ba/sake/hepek/pure/component/PureGridComponents.scala
@@ -8,45 +8,17 @@ object PureGridComponents extends PureGridComponents
 trait PureGridComponents extends GridComponents {
   import GridComponents._
 
-  override def row(content: Frag*) =
+  override def mkRow(content: Frag*): Frag =
     div(cls := "pure-g")(content)
 
-  override def row(half1: Half1, half2: Half2) =
-    row(half1.content ++ half2.content)
-
-  override def row(third1: Third1, third2: Third2, third3: Third3) =
-    row(third1.content ++ third2.content ++ third3.content)
-
-  // HALF
-  override def half1(content: Frag*) = {
-    val classes = halfRatioClasses(0)
-    val c       = div(cls := classes.mkString(" "))(content)
-    Half1(List(c))
+  override def mkCol2(index: Int, content: List[Frag]): Frag = {
+    val classes = halfRatioClasses(index)
+    div(cls := classes.mkString(" "))(content)
   }
 
-  override def half2(content: Frag*) = {
-    val classes = halfRatioClasses(1)
-    val c       = div(cls := classes.mkString(" "))(content)
-    Half2(List(c))
-  }
-
-  // THIRD
-  override def third1(content: Frag*) = {
-    val classes = thirdRatioClasses(0)
-    val c       = div(cls := classes.mkString(" "))(content)
-    Third1(List(c))
-  }
-
-  override def third2(content: Frag*) = {
-    val classes = thirdRatioClasses(1)
-    val c       = div(cls := classes.mkString(" "))(content)
-    Third2(List(c))
-  }
-
-  override def third3(content: Frag*) = {
-    val classes = thirdRatioClasses(2)
-    val c       = div(cls := classes.mkString(" "))(content)
-    Third3(List(c))
+  override def mkCol3(index: Int, content: List[Frag]): Frag = {
+    val classes = thirdRatioClasses(index)
+    div(cls := classes.mkString(" "))(content)
   }
 
   /* HELPERS */
@@ -80,9 +52,9 @@ trait PureGridComponents extends GridComponents {
     "pure-u-lg-" + ratioValue(ratio, index) + "-24"
 
   private def ratioValue(ratio: Ratio, index: Int): Int =
-    ratio2BS(ratio.values(index), ratio.values)
+    ratio2Pure(ratio.values(index), ratio.values)
 
   // for args 1,1:2 => (1/3)*24 == 8
-  private def ratio2BS(ratio: Int, allRatios: List[Int]): Int =
+  private def ratio2Pure(ratio: Int, allRatios: List[Int]): Int =
     ((ratio / allRatios.sum.toDouble) * 24).toInt
 }

--- a/src/main/scala/ba/sake/hepek/pure/component/PureGridComponents.scala
+++ b/src/main/scala/ba/sake/hepek/pure/component/PureGridComponents.scala
@@ -8,15 +8,15 @@ object PureGridComponents extends PureGridComponents
 trait PureGridComponents extends GridComponents {
   import GridComponents._
 
-  override def mkRow(content: Frag*): Frag =
+  private[hepek] override def mkRow(content: Frag*): Frag =
     div(cls := "pure-g")(content)
 
-  override def mkCol2(index: Int, content: List[Frag]): Frag = {
+  private[hepek] override def mkCol2(index: Int, content: List[Frag]): Frag = {
     val classes = halfRatioClasses(index)
     div(cls := classes.mkString(" "))(content)
   }
 
-  override def mkCol3(index: Int, content: List[Frag]): Frag = {
+  private[hepek] override def mkCol3(index: Int, content: List[Frag]): Frag = {
     val classes = thirdRatioClasses(index)
     div(cls := classes.mkString(" "))(content)
   }

--- a/src/main/scala/ba/sake/hepek/pure/statik/PureStaticPage.scala
+++ b/src/main/scala/ba/sake/hepek/pure/statik/PureStaticPage.scala
@@ -15,8 +15,8 @@ trait PureStaticPage extends StaticPage with PureDependencies {
     if (withPureMenu) {
       import grid._
       row(
-        half1(sidebarMenu),
-        half2(pageContent)
+        half(sidebarMenu),
+        half(pageContent)
       )
     } else pageContent
 

--- a/src/main/scala/ba/sake/hepek/theme/bootstrap3/HepekBootstrap3BlogPage.scala
+++ b/src/main/scala/ba/sake/hepek/theme/bootstrap3/HepekBootstrap3BlogPage.scala
@@ -43,8 +43,8 @@ trait HepekBootstrap3BlogPage extends BlogPostPage with BootstrapStaticPage {
     }
 
     frag(
-      pageHeader.map(ph => row(ph)),
-      row(
+      pageHeader,
+      mkRow(
         div(cls := "col-lg-2 col-lg-offset-1  col-md-3  hidden-print")(
           renderSidebar
         ),

--- a/tests/src/main/scala/ba/sake/hepek/bulma/statik/MockBulmaPage.scala
+++ b/tests/src/main/scala/ba/sake/hepek/bulma/statik/MockBulmaPage.scala
@@ -86,29 +86,29 @@ object MockBulmaPage extends BulmaStaticPage with BulmaGridComponents {
     breadcrumb,
     menu,
     row(
-      third1(
+      third(
         dropdown
       ),
-      third2(
+      third(
         panel
       ),
-      third3(
+      third(
         tabs
       )
     ),
     row(
-      half1(
+      half(
         card
       ),
-      half2(
+      half(
         pagination
       )
     ),
     row(
-      half1(
+      half(
         message
       ),
-      half2(
+      half(
         panel
       )
     ),


### PR DESCRIPTION
This is a cleanup of rows/halves/thirds. Fixes #37 
Before:
```
row(
  half1(..),
  half2()
)
```
After:
```
row(
  half(..),
  half()
)
```

Also, now you just override `mkRow`, `mkCol2` (halves) and `mkCol3` (thirds) in order to support a new grid framework.  
@P3trur0 @sorenbug