### PR TITLE
Update scalatags version to com.lihaoyi 0.7.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,7 @@ lazy val hepekComponents = (project in file("hepek-components"))
   .settings(
     name := "hepek-components",
     libraryDependencies ++= Seq(
-      //"com.lihaoyi"   %% "scalatags" % "0.6.8",
-      "ba.sake"                  %% "scalatags" % "0.6.8-SNAPSHOT",
+      "com.lihaoyi"   %% "scalatags" % "0.7.0",
       "com.atlassian.commonmark" % "commonmark" % "0.13.0",
       "org.scalatest"            %% "scalatest" % scalaTestVersion % "test"
     )


### PR DESCRIPTION
This updates the scalatags dependency to be `com.lihaoyi:scalatags:0.7.0` and no longer a snapshot version.