### PR TITLE
Add HTMX deps and attrs

### DIFF
--- a/hepek-components/jvm/src/main/scala/ba/sake/hepek/htmx/HtmxDependencies.scala
+++ b/hepek-components/jvm/src/main/scala/ba/sake/hepek/htmx/HtmxDependencies.scala
@@ -1,0 +1,22 @@
+package ba.sake.hepek.htmx
+
+import ba.sake.hepek.html.*
+
+/** @see
+  *   https://htmx.org/
+  */
+trait HtmxDependencies extends PageDependencies {
+
+  def htmxSettings: ComponentSettings =
+    ComponentSettings("1.9.10", "anchor-js").withDepsProvider(DependencyProvider.unpkg)
+
+  def htmxDependencies: ComponentDependencies =
+    ComponentDependencies.default.withJsDependencies(
+      Dependencies.default.withDeps(
+        Dependency("htmx.min.js", htmxSettings.version, htmxSettings.pkg).withBaseFolder("dist/")
+      )
+    )
+
+  override def components =
+    super.components.appended(htmxSettings -> htmxDependencies)
+}

--- a/hepek-components/jvm/src/main/scala/ba/sake/hepek/htmx/HtmxDependencies.scala
+++ b/hepek-components/jvm/src/main/scala/ba/sake/hepek/htmx/HtmxDependencies.scala
@@ -8,7 +8,7 @@ import ba.sake.hepek.html.*
 trait HtmxDependencies extends PageDependencies {
 
   def htmxSettings: ComponentSettings =
-    ComponentSettings("1.9.10", "anchor-js").withDepsProvider(DependencyProvider.unpkg)
+    ComponentSettings("1.9.10", "htmx.org").withDepsProvider(DependencyProvider.unpkg)
 
   def htmxDependencies: ComponentDependencies =
     ComponentDependencies.default.withJsDependencies(

--- a/hepek-components/jvm/src/main/scala/ba/sake/hepek/htmx/hx.scala
+++ b/hepek-components/jvm/src/main/scala/ba/sake/hepek/htmx/hx.scala
@@ -1,0 +1,125 @@
+package ba.sake.hepek.htmx
+
+import ba.sake.hepek.scalatags.all.*
+
+object hx {
+
+  /** Fires a GET request to the specified URL */
+  val get = attr("hx-get")
+
+  /** Fires a POST request to the specified URL */
+  val post = attr("hx-post")
+
+  /** Fires a PUT request to the specified URL */
+  val put = attr("hx-put")
+
+  /** Fires a PATCH request to the specified URL */
+  val patch = attr("hx-patch")
+
+  /** Fires a DELETE request to the specified URL */
+  val delete = attr("hx-delete")
+
+  /** adds to the headers that will be submitted with the request */
+  val headers = attr("hx-headers")
+
+  /** JSON-formatted parameters that will be submitted with an AJAX request */
+  val vals = attr("hx-vals")
+
+  /** specifies the event that triggers the request */
+  val trigger = attr("hx-trigger")
+
+  /** specifies the target element to be swapped */
+  val target = attr("hx-target")
+
+  /** select content to swap in from a response */
+  val select = attr("hx-select")
+
+  /** select content to swap in from a response, out of band (somewhere other than the target)
+    */
+  val selectOob = attr("hx-select-oob")
+
+  /** controls how content is swapped in (outerHTML, beforeend, afterend, ..) */
+  val swap = attr("hx-swap")
+
+  /** marks content in a response to be out of band (should swap in somewhere other than the target)
+    */
+  val swapOob = attr("hx-swap-oob")
+
+  /** handle events with a inline scripts on elements */
+  val on = attr("hx-on")
+
+  /** add or remove progressive enhancement for links and forms */
+  val boost = attr("hx-boost")
+
+  /** pushes the URL into the browser location bar, creating a new history entry
+    */
+  val pushUrl = attr("hx-push-url")
+
+  /** shows a confirm() dialog before firing a request */
+  val confirm = attr("hx-confirm")
+
+  /** disables htmx processing for the given node and any children nodes */
+  val disable = attr("hx-disable")
+
+  /** adds the disabled attribute to the specified elements while a request is in flight
+    */
+  val disabledElt = attr("hx-hx-disabled-elt")
+
+  /** control and disable automatic attribute inheritance for child nodes */
+  val disinherit = attr("hx-disinherit")
+
+  /** changes the request encoding type */
+  val encoding = attr("hx-encoding")
+
+  /** extensions to use for this element. See https://htmx.org/extensions/
+    */
+  val ext = attr("hx-ext")
+
+  /** prevent sensitive data being saved to the history cache */
+  val history = attr("hx-history")
+
+  /** the element to snapshot and restore during history navigation */
+  val historyElt = attr("hx-history-elt")
+
+  /** include additional data in requests */
+  val include = attr("hx-include")
+
+  /** the element to put the htmx-request class on during the request */
+  val indicator = attr("hx-indicator")
+
+  /** filters the parameters that will be submitted with a request */
+  val params = attr("hx-params")
+
+  /** specifies elements to keep unchanged between requests */
+  val preserve = attr("hx-preserve")
+
+  /** shows a prompt() before submitting a request */
+  val prompt = attr("hx-prompt")
+
+  /** replace the URL in the browser location bar */
+  val replaceUrl = attr("hx-replace-url")
+
+  /** configures various aspects of the request */
+  val request = attr("hx-request")
+
+  /** control how requests made by different elements are synchronized */
+  val sync = attr("hx-sync")
+
+  /** force elements to validate themselves before a request */
+  val validate = attr("hx-validate")
+
+  //////////////// SSE
+  /** https://htmx.org/extensions/server-sent-events/ */
+  val sseConnect = attr("sse-connect")
+
+  /** https://htmx.org/extensions/server-sent-events/ */
+  val sseSwap = attr("sse-swap")
+
+  ////////////// WS
+  /** https://htmx.org/extensions/web-sockets/ */
+  val wsConnect = attr("ws-connect")
+
+  /** https://htmx.org/extensions/web-sockets/ */
+  val wsSend = attr("ws-send")
+
+}

--- a/hepek-components/shared/src/main/scala/ba/sake/hepek/html/DependencyProvider.scala
+++ b/hepek-components/shared/src/main/scala/ba/sake/hepek/html/DependencyProvider.scala
@@ -7,12 +7,12 @@ trait DependencyProvider {
 /* Dependency providers: CDNs, Webjars etc. */
 object DependencyProvider {
 
-  val unpkg: DependencyProvider = (dep: Dependency) => {
+  val unpkg: DependencyProvider = dep => {
     val maybeBaseFolder = dep.baseFolder.getOrElse("")
     s"https://unpkg.com/${dep.pkg}@${dep.version}/${maybeBaseFolder}${dep.file}${dep.queryParams}"
   }
 
-  val cdnjs: DependencyProvider = (dep: Dependency) =>
+  val cdnjs: DependencyProvider = dep =>
     s"https://cdnjs.cloudflare.com/ajax/libs/${dep.pkg}/${dep.version}/${dep.file}${dep.queryParams}"
 
   // TODO add jsdeliver and more


### PR DESCRIPTION
Fixes #273 

CC: @carlos-verdes

Let me know what you think and we can merge.

I wanted to dig into HTMX for a long time, but didnt have much chance.. 😄  
Always liked the approach of "server-side-html + a sprinkle of JS".  
HTMX makes it waaay easier to add some dynamic stuff into your page.


---

This PR enables you to write this:
```scala
import ba.sake.hepek.htmx.*
import ba.sake.hepek.html.HtmlPage
import ba.sake.hepek.scalatags.all.*

trait MyPage extends HtmlPage with HtmxDependencies

object IndexView extends MyPage:
  override def bodyContent = div(
    button(hx.post := "/some-url", hx.swap := "outerHTML")(
      "Click me!"
    )
  )
```

I think it's enough to get us started.  
Few things to mention from your example in the issue:
- I still need to go through HTMX extensions and add their deps too, similar what we have for PrismJS, you can add them manually for now
- not sure adding enum for hx-swap would add much benefit, since you can write stuff like `hx-swap="innerHTML swap:1s"`. But surely we'd avoid typos, maybe we should add it then, not sure....
https://htmx.org/attributes/hx-swap/
